### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,21 +20,21 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true


### PR DESCRIPTION
Upgrades all GitHub Actions to their latest releases and pins each to a full commit SHA (with a `# vX.Y.Z` comment) so a moving tag can't silently change what runs in CI — standard supply-chain hardening.

## Bumps

| Action | Was | Now | Pinned SHA |
|---|---|---|---|
| [actions/checkout](https://github.com/actions/checkout/releases/tag/v7.0.0) | v6 | v7.0.0 | `9c091bb` |
| [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action/releases/tag/v4.2.0) | v3 | v4.2.0 | `bb05f3f` |
| [docker/login-action](https://github.com/docker/login-action/releases/tag/v4.4.0) | v3 | v4.4.0 | `af1e73f` |
| [docker/metadata-action](https://github.com/docker/metadata-action/releases/tag/v6.2.0) | v5 | v6.2.0 | `dc80280` |
| [docker/build-push-action](https://github.com/docker/build-push-action/releases/tag/v7.3.0) | v6 | v7.3.0 | `53b7df9` |

The workflow uses only stable inputs (`context` / `push` / `tags` / `labels` / `cache-from` / `cache-to`), which are unchanged across these major versions, so no config changes are needed. YAML validated and every `uses:` resolves to a 40-char commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
