### PR TITLE
v3.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@
 # ############ STAGE 1 ################
 # #####################################
 
-ARG VALHALLA_VERSION=3.8.0
-ARG VALHALLA_COMMIT=eb343e23d59610b108c701ba0d0f5b0dd0b2cff3
+ARG VALHALLA_VERSION=3.8.1
+ARG VALHALLA_COMMIT=52705fa2641d172b5507e1e7a6401eb7c1f7d871
 ARG PRIME_SERVER_COMMIT=5985bc63223c5f77c9cd1430bb92317bb08db2aa
 # Parallelism for the Valhalla compile. Defaults to all cores (used by CI).
 # Override for memory-constrained local builds, e.g. --build-arg MAKE_JOBS=2,


### PR DESCRIPTION
Bumps Valhalla to [3.8.1](https://github.com/valhalla/valhalla/releases/tag/3.8.1) (commit `52705fa`) to stay current. prime_server stays at 0.13.0.

3.8.1 is a patch with **nothing relevant to this image**. The full [3.8.0…3.8.1 diff](https://github.com/valhalla/valhalla/compare/3.8.0...3.8.1) is:

- a `cibuildwheel` / PyPI CI fix ([#6179](https://github.com/valhalla/valhalla/issues/6179)) — Python wheels, which we build with `ENABLE_PYTHON_BINDINGS=OFF`
- a `struct` → `class` forward-declaration tag fix in `loki/tiles.h` (silences a mismatched-tag warning; no behavior change)
- the `VALHALLA_VERSION_PATCH` bump

No routing, costing, or binary-relevant change over 3.8.0, so I skipped a local recompile — the 3.8.0 build + real-tile routing validation from #10 still holds. No tilecutter impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
